### PR TITLE
feat: agregar la migracion de la tabla platform_admin

### DIFF
--- a/app/Database/Migrations/2025-06-07-025523_PlatformAdmins.php
+++ b/app/Database/Migrations/2025-06-07-025523_PlatformAdmins.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class PlatformAdmins extends Migration
+{
+    public function up()
+    {
+         $this->forge->addField([
+            'id' => [
+                'type'           => 'INT',
+                'constraint'     => 5,
+                'unsigned'       => true,
+                'auto_increment' => true,
+            ],
+            'name' => [
+                'type'       => 'VARCHAR',
+                'constraint' => '255',
+            ],
+            'email' => [
+                'type' => 'VARCHAR',
+                'constraint' => '255',
+                'unique'=>true,
+            ],
+            'password' => [
+                'type' => 'VARCHAR',
+                'constraint' => '255',
+            ],
+            'role' => [
+                'type' => 'ENUM',
+                'constraint' => ['super_admin', 'platform_admin', 'support'],
+                'default' => 'support',
+                'null' => false
+            ],
+            'is_active'=>[
+                'type'=>'BOOLEAN',
+                'default'=>true,
+            ],
+            'created_at'=>[
+                'type'=>'TIMESTAMP',
+            ],
+            'update_at'=>[
+                'type'=>'TIMESTAMP',
+            ],
+            'delete_at'=>[
+                'type'=>'TIMESTAMP',
+            ],
+        ]);
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('platform_admins');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('platform_admins');
+    }
+}

--- a/app/Database/Migrations/2025-06-07-034448_AlterPlatformAdmins.php
+++ b/app/Database/Migrations/2025-06-07-034448_AlterPlatformAdmins.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AlterPlatformAdmins extends Migration
+{
+    public function up()
+    {
+        $this->forge->modifyColumn('platform_admins', [
+            'role' => [
+                'type' => 'ENUM',
+                'constraint' => ['admin', 'businessman'],
+                'default' => 'businessman',
+                'null' => false
+            ]
+        ]);
+        $this->forge->renameTable('platform_admins', 'app_user');
+    }
+
+    public function down()
+    {
+        $fields = [
+            'role' => [
+                'type' => 'ENUM',
+                'constraint' => ['super_admin', 'platform_admin', 'support'],
+                'default' => 'support',
+                'null' => false
+            ]
+        ];
+        $this->forge->modifyColumn('app_user', $fields);
+        $this->forge->renameTable('app_user', 'platform_admins');
+    }
+}


### PR DESCRIPTION
cambia el nombre de la tabla de 'platform_admin' a 'app_user', se usara como tabla para todos los usuarios, ademas de modificar el campo role, ahora los valores son 'admin', 'businessman' y se usan para indicar si el usuario es admin o un emprendor.